### PR TITLE
[ISSUE#6] include classifier when storing artifacts that are not found

### DIFF
--- a/src/main/java/com/commsen/maven/plugin/bomhelper/BomResolveMojo.java
+++ b/src/main/java/com/commsen/maven/plugin/bomhelper/BomResolveMojo.java
@@ -76,7 +76,7 @@ public class BomResolveMojo extends BomHelperAbstractMojo {
 			try {
 				artifactResolver.resolveArtifact(projectBuildingRequest, coordinate);
 			} catch (ArtifactResolverException e) {
-				failedArtifacts.add(dependency.toString());
+				failedArtifacts.add(coordinate.toString());
 				logger.error("Failed to resolve artifact " + coordinate, e);
 			}
 		}


### PR DESCRIPTION
The method dependency.toString() ignores the classifier, so just one artifact is added to the Set<String>

Fixes #6 