### PR TITLE
Infer extension and classifier from dependency type

### DIFF
--- a/src/it/simple-it/pom.xml
+++ b/src/it/simple-it/pom.xml
@@ -4692,6 +4692,12 @@
         <groupId>com.liferay.portal</groupId>
         <version>4.1.0</version>
       </dependency>
+      <dependency>
+        <artifactId>guava-testlib</artifactId>
+        <groupId>com.google.guava</groupId>
+        <version>33.3.1-jre</version>
+        <type>test-jar</type>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
The extension and classifier for artifact coordinates can be inferred directly from the type without specifying them in the plugin configuration.

It also fixes issue #11 